### PR TITLE
Fix for source_type === 'global' on multisites. This fixes the

### DIFF
--- a/src/Fieldtypes/FieldItemRelationshipFieldtype.php
+++ b/src/Fieldtypes/FieldItemRelationshipFieldtype.php
@@ -53,8 +53,13 @@ class FieldItemRelationshipFieldtype extends Fieldtype
                     'error_message' => "Global set \"{$this->config('source_global_set')}\" not found.",
                 ];
             }
-
-            $sourceValue = $global->inCurrentSite()->get($this->config('source_field'));
+            
+            $site = request()->query('site');
+            if ($site) {
+              $sourceValue = $global->in($site)->get($this->config('source_field'));
+            } else {
+              $sourceValue = $global->inCurrentSite()->get($this->config('source_field'));
+            }
 
             if (!$sourceValue) {
                 return [


### PR DESCRIPTION
source_global when using the field in a global set. Retrieving the data using the URL query parameter that Statamic automatically sets in the URL is more reliable on multisites that have sites configured on the same domain.